### PR TITLE
Remove gem version from docs

### DIFF
--- a/onboarding/rack.md
+++ b/onboarding/rack.md
@@ -3,7 +3,7 @@
 Add to your Gemfile:
 
 ```ruby
-gem 'rollbar', '~> 2.8.3'
+gem 'rollbar'
 ```
 
 Then run:

--- a/onboarding/rails.md
+++ b/onboarding/rails.md
@@ -3,7 +3,7 @@
 Add to your Gemfile:
 
 ```ruby
-gem 'rollbar', '~> 2.8.3'
+gem 'rollbar'
 ```
 
 Then run:

--- a/onboarding/ruby.md
+++ b/onboarding/ruby.md
@@ -3,7 +3,7 @@
 Add to your Gemfile:
 
 ```ruby
-gem 'rollbar', '~> 2.8.3'
+gem 'rollbar'
 ```
 
 Then run:


### PR DESCRIPTION
I think this is the best idea for few reasons:

- We need to update this every time we release a new gem.
- In general new users will want to use the last version. Or not the
  last version, but the version that fits dependencies with their other libraries.
- This is responsability of the cusetomer.