### PR TITLE
Remove false info about JSON params from notification variables

### DIFF
--- a/guides/notification-variables.md
+++ b/guides/notification-variables.md
@@ -42,8 +42,6 @@ Variable | Description/Values
 `{{"{{status"}}}}` | `Active`, `Resolved`, `Muted`
 `{{"{{occurrence_title"}}}}` | Same as item title
 `{{"{{occurrence_link"}}}}` | Occurrence URL
-*JSON payload values* | Any data value sent in the JSON payload of an occurrence may be used as a variable, including custom data.  Examples of usage are `{{"{{request.url"}}}}` and `{{"{{server.host"}}}}`.  If your JSON payload includes the custom values `{{"{{ handler: { key: process-job, id:100"}}}}` then you can use the variables `{{"{{handler.key"}}}}` and `{{"{{handler.id"}}}}` in your notifications.  To view the full set of available values, look at the "Params" values of an occurrence in your project. 
-
 
 ## Deploys
 When a deploy triggers a notification, the following variables are available:

--- a/tools/slack.md
+++ b/tools/slack.md
@@ -33,5 +33,6 @@ Configuration is per-project in Rollbar.
 ### Tips & Tricks
 
 * You can customize the content of Slack messages using [notication variables](/docs/notification-variables/).
+* In addition to notification variables, any data value sent in the JSON payload of an item or occurrence may be used as a variable, including custom data. Examples of usage are {{"{{request.url"}}}} and {{"{{server.host"}}}}. If your JSON payload includes the custom values {{"{{ handler: { key: process-job, id:100"}}}} then you can use the variables {{"{{handler.key"}}}} and {{"{{handler.id"}}}} in your notifications. To view the full set of available values, look at the "Params" values of an occurrence in your project.
 * You can mention specific Slack users in notification messages using the syntax `@username`
 * To mention `@channel`, `@group`, `@here`, or `@everyone`, use the syntax `<!channel>`, `<!group>`, `<!here>`, or `<!everyone>`.

--- a/tools/slack.md
+++ b/tools/slack.md
@@ -33,6 +33,6 @@ Configuration is per-project in Rollbar.
 ### Tips & Tricks
 
 * You can customize the content of Slack messages using [notication variables](/docs/notification-variables/).
-* In addition to notification variables, any data value sent in the JSON payload of an item or occurrence may be used as a variable, including custom data. Examples of usage are {{"{{request.url"}}}} and {{"{{server.host"}}}}. If your JSON payload includes the custom values {{"{{ handler: { key: process-job, id:100"}}}} then you can use the variables {{"{{handler.key"}}}} and {{"{{handler.id"}}}} in your notifications. To view the full set of available values, look at the "Params" values of an occurrence in your project.
+* In addition to notification variables, any data value sent in the JSON payload of an item or occurrence may be used as a variable, including custom data. Examples of usage are {{"{{body.request.url"}}}} and {{"{{body.server.host"}}}}. If your JSON payload includes the custom values {{"{{ handler: { key: process-job, id:100"}}}} then you can use the variables {{"{{body.handler.key"}}}} and {{"{{body.handler.id"}}}} in your notifications. To view the full set of available values, look at the "Params" values of an occurrence in your project. All params besides the ones listed in the above notification variables *must* be prefaced with "body".
 * You can mention specific Slack users in notification messages using the syntax `@username`
 * To mention `@channel`, `@group`, `@here`, or `@everyone`, use the syntax `<!channel>`, `<!group>`, `<!here>`, or `<!everyone>`.


### PR DESCRIPTION
Add the same info to the Slack docs, based on https://github.com/rollbar/mox/pull/1649