### PR TITLE
add backslash to escape * in custom grouping example

### DIFF
--- a/guides/custom-grouping.md
+++ b/guides/custom-grouping.md
@@ -176,10 +176,10 @@ Here's an example complete configuration with three rules.
     "fingerprint": "connection-error",
     "title": "Connection error"
   },
-  { 
+  {
     "condition": {"all": [
       {"path": "body.trace.exception.class", "eq": "TimeoutError"},
-      {"path": "body.trace.frames.*.filename", "contains": "payments"}
+      {"path": "body.trace.frames.\*.filename", "contains": "payments"}
     ]},
     "fingerprint": "payments-timeout-error",
     "title": "Timeout error in payments code"


### PR DESCRIPTION
double check me that this is the correct syntax here? @ezarowny 