### PR TITLE
Updating bots guide language about checkIgnore in other SDKs

### DIFF
--- a/guides/filter-or-ignore-errors-from-bots.md
+++ b/guides/filter-or-ignore-errors-from-bots.md
@@ -60,6 +60,5 @@ _rollbarConfig = {
 }
 ```
 
-Our other libraries don't implement `checkIgnore` yet, so if you'd like
-this somewhere else, please open an issue on the appropriate repo in
-GitHub.
+Some of our other libraries don't implement `checkIgnore` yet. Please check out the docs for your SDK to see if `checkIgnore` is implemented, and open an issue on the appropriate repo in
+GitHub if you'd like `checkIgnore` in an SDK that hasn't implemented it yet.

--- a/guides/filter-or-ignore-errors-from-bots.md
+++ b/guides/filter-or-ignore-errors-from-bots.md
@@ -60,5 +60,4 @@ _rollbarConfig = {
 }
 ```
 
-Some of our other libraries don't implement `checkIgnore` yet. Please check out the docs for your SDK to see if `checkIgnore` is implemented, and open an issue on the appropriate repo in
-GitHub if you'd like `checkIgnore` in an SDK that hasn't implemented it yet.
+Some of our other libraries don't implement `checkIgnore` yet. Please check out the docs for your SDK to see if `checkIgnore` is implemented, and open an issue on the appropriate repo in GitHub if you'd like `checkIgnore` in an SDK that hasn't implemented it yet.


### PR DESCRIPTION
We have `checkIgnore` in PHP, and you can use the `before_process` hook in Ruby, so the previous language was outdated. To avoid having to update this doc every time an SDK implements `checkIgnore`, I think this language makes sense. 