### PR TITLE
Update onboarding environments

### DIFF
--- a/onboarding/flask.md
+++ b/onboarding/flask.md
@@ -31,7 +31,7 @@ def init_rollbar():
         # access token
         '{{ server_access_token }}',
         # environment name
-        'testing',
+        'production',
         # server root directory, makes tracebacks prettier
         root=os.path.dirname(os.path.realpath(__file__)),
         # flask already sets up logging

--- a/onboarding/java.md
+++ b/onboarding/java.md
@@ -52,7 +52,7 @@ public class Application {
 
   public Application() {
     Config config = withAccessToken("{{ server_access_token }}")
-        .environment("development")
+        .environment("production")
         .codeVersion("1.0.0")
         .build();
     this.rollbar = Rollbar.init(config);

--- a/onboarding/php.md
+++ b/onboarding/php.md
@@ -17,7 +17,7 @@ use \Rollbar\Payload\Level;
 Rollbar::init(
 	array(
 		'access_token' => '{{ server_access_token }}',
-		'environment' => 'development'
+		'environment' => 'production'
 	)
 );
 ```


### PR DESCRIPTION
Replace environment = 'development' with 'production' in a couple of onboarding instructions.