### PR TITLE
Remove unnecessary dependencies from the Pyramid example

### DIFF
--- a/onboarding/pyramid.md
+++ b/onboarding/pyramid.md
@@ -9,7 +9,6 @@ pip install rollbar
 ```ini
 [app:main]
 pyramid.includes =
-    pyramid_debugtoolbar
     rollbar.contrib.pyramid
 ```
       


### PR DESCRIPTION
`pyrollbar` doesn't use `pyramid_debugtoolbar`.

Also, according to the docs (https://docs.pylonsproject.org/projects/pyramid_debugtoolbar/en/latest/):

> The debug toolbar should never be enabled in a production environment or on a machine with its Pyramid HTTP port exposed directly to the internet; it allows arbitrary code execution from only semi-trusted sources when configured poorly.

As we use `production` environment in the example, definitely we shouldn't show some bad habits here ;)

Story details: https://app.clubhouse.io/rollbar/story/79975