### PR TITLE
Update Java onboarding snippet to close Rollbar instance before exiting

### DIFF
--- a/onboarding/java.md
+++ b/onboarding/java.md
@@ -48,7 +48,7 @@ import static com.rollbar.notifier.config.ConfigBuilder.withAccessToken;
 import com.rollbar.notifier.Rollbar;
 import com.rollbar.notifier.config.Config;
 
-public class Application {
+public class Application implements AutoCloseable {
   private Rollbar rollbar;
 
   public Application() {
@@ -58,10 +58,16 @@ public class Application {
         .build();
     this.rollbar = Rollbar.init(config);
   }
+  
+  @Override
+  public void close() throws Exception {
+    this.rollbar.close(true);
+  }
 
-  public static void main(String[] args) {
-    Application app = new Application();
-    app.execute();
+  public static void main(String[] args) throws Exception {
+    try (Application app = new Application()) {
+      app.execute();
+    }
   }
 
   private void execute() {


### PR DESCRIPTION
## Description of the change

This updates the Java onboarding doc, fixing a snippet that didn't work because the application process exited before our send task ran.  

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues

None

## Checklists
### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request