### PR TITLE
Update Node Lambda examples, include async example

### DIFF
--- a/onboarding/lambdajs.md
+++ b/onboarding/lambdajs.md
@@ -17,21 +17,34 @@ This will result in a directory structure like:
 
 ## Sending a test message to Rollbar
 
-```javascript    
-    // require and initialize Rollbar
-    var Rollbar = require('rollbar');
-    var rollbar = new Rollbar({accessToken: "{{ server_access_token }}"});
+Rollbar provides a wrapper for your Lambda function. This wrapper works with both
+async and non-async function types. Simply pass your handler to `rollbar.lambdaHandler()`
 
-    exports.handler = (event, context, callback) => {
-      // log a message and send it to Rollbar
-      rollbar.log('Hello, Lambda');
-      var resp = {
-        "isBase64Encoded": false,
-        "statusCode": 200,
-        "body": '{"hello": "lambda"}'
-      };
-      callback(null, resp);
-    };
+### Async Lambda Handler
+```javascript
+// require and initialize Rollbar
+const Rollbar = require('rollbar');
+const rollbar = new Rollbar({accessToken: "{{ server_access_token }}"});
+
+exports.handler = rollbar.lambdaHandler(async (event, context) => {
+  // log a message and send it to Rollbar
+  rollbar.log('Hello, Lambda');
+  return 'ok';
+}
 ```
 
-For full instructions on integrating Rollbar in your Lambda functions, see our [Rollbar.js docs](/docs/notifier/rollbar.js/#lambda).
+### Non-Async Lambda Handler
+```javascript
+// require and initialize Rollbar
+const Rollbar = require('rollbar');
+const rollbar = new Rollbar({accessToken: "{{ server_access_token }}"});
+
+exports.handler = rollbar.lambdaHandler((event, context, callback) => {
+  // log a message and send it to Rollbar
+  rollbar.log('Hello, Lambda');
+  callback(null, 'ok');
+});
+```
+
+For full instructions on integrating Rollbar in your Lambda functions, see our
+[Rollbar.js docs](https://rollbar.com/docs/notifier/aws-lambda/).


### PR DESCRIPTION
## Description of the change

This PR updates and fixes the non-async example, and adds an async example.

Lambda currently expects the return value to be a string type. I'm not sure whether the object type in the original example would have worked at some time in the past. The Rollbar wrapper just passes through the return value as is. Therefore these examples use the simplest thing that works and focus on the parts that are relevant to the Rollbar integration.

Wait behavior: Rollbar's wait on exit behavior is now built into the wrapper for all success and error cases. The integrator doesn't need to do anything when using the wrapper.

These examples have been tested in AWS Lambda using current Rollbar.js.

The SDK doc link has also been updated. 

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Doc

## Related issues

ch82074
ch78403

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request