### PR TITLE
Update Java onboarding doc to link to full documentation, and configu…

### DIFF
--- a/onboarding/java.md
+++ b/onboarding/java.md
@@ -1,3 +1,5 @@
+This is a quick starter guide for basic Java applications: You can check further instructions for supported Java frameworks in our <a href="https://docs.rollbar.com/docs/java#usage" target="_blank" rel="noopener">Complete Java Documentation</a>.
+
 # Installation
 
 ## Using Gradle
@@ -85,7 +87,7 @@ A more full-featured example can be found <a href="https://github.com/rollbar/ro
 
 # Further Configuration
 
-All configuration is done via the Config object in `rollbar-java`. You can see the interface <a href="https://github.com/rollbar/rollbar-java/blob/master/rollbar-java/src/main/java/com/rollbar/notifier/config/Config.java" target="_blank" rel="noopener">here</a>.
+For more advanced configuration options, visit our <a href="https://javadoc.io/doc/com.rollbar/rollbar-java/latest/com/rollbar/notifier/config/Config.html" target="_blank" rel="noopener">Complete Java Configuration reference</a>.
 
 # Spring
 


### PR DESCRIPTION
This PR adds a link to the full Java SDK docs at the top, and replaces the copy and configuration link at the bottom to point to the javadoc instead of the configuration source code. 

## Description of the change

> Description here
## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues

## Checklists
### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request