### PR TITLE
remove alpha message from go sdk

### DIFF
--- a/onboarding/go.md
+++ b/onboarding/go.md
@@ -1,8 +1,3 @@
-<div class="alert alert-info">
-	Rollbar's Go SDK is currently a <code>alpha</code> release.  For details, please see the <a href="https://github.com/rollbar/rollbar-go/blob/master/README.md">Readme</a>.<br>
-	To report issues, make suggestions, or ask questions, please <a href="https://github.com/rollbar/rollbar-go/issues/new">create an issue in Github</a>.
-</div>
-
 ## Installation
 
 To send errors to Rollbar from your Go application, you should use our <a href="https://github.com/rollbar/rollbar-go" target="_blank" rel="noopener">rollbar-go</a> SDK.


### PR DESCRIPTION
## Description of the change

Go SDK is not alpha anymore, so removing this warning message. 

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues

> Fix [#1]() 
## Checklists
### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [x] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request